### PR TITLE
fix: add ec2>instance launched_at field in metadata

### DIFF
--- a/src/plugin/metadata/ec2/instance.yaml
+++ b/src/plugin/metadata/ec2/instance.yaml
@@ -200,7 +200,7 @@ search:
   - Key Pair: data.compute.keypair
   - Image: data.compute.image
   - Availability Zone: data.compute.az
-  - Launched At: data.compute.launched_at
+  - Launched: data.compute.launched_at
   - OS Type: data.os.os_type
   - OS Details: data.os.details
   - OS Architecture: data.os.os_arch


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
add ec2>instance launched_at field in metadata